### PR TITLE
Add support for relation table events.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,15 @@ services:
       MESSAGE_BROKER_ADDRESS: rabbitmq
       API_HOST: http://gobapi:8001
       GOB_SHARED_DIR: /app/shared
-      GOB_EVENTPRODUCER_DATABASE_HOST: eventproducer_database
+      GOB_EVENTPRODUCER_DATABASE_HOST: producer-database
       GOB_EVENTPRODUCER_DATABASE_PORT: 5432
       GOB_EVENTPRODUCER_DATABASE_USER: gob_eventproducer
       GOB_EVENTPRODUCER_DATABASE_PASSWORD: insecure
       GOB_EVENTPRODUCER_DATABASE: gob_eventproducer
       GOB_DATABASE_PORT_OVERRIDE: 5432
       GOB_DATABASE_HOST_OVERRIDE: database
+    depends_on:
+      - producer-database
 
     volumes:
       - gob-volume:/app/shared
@@ -23,10 +25,10 @@ services:
       - ${GOB_CORE_DIR-../GOB-Core}:/app/GOB-Core
       - ${GOB_CONFIG_DIR-../GOB-Config}:/app/GOB-Config
 
-  eventproducer_database:
+  producer-database:
     image: amsterdam/postgres11
     ports:
-      - "5430:5432"
+      - "5429:5432"
     environment:
       POSTGRES_PASSWORD: insecure
       POSTGRES_DB: gob_eventproducer

--- a/src/gobeventproducer/__main__.py
+++ b/src/gobeventproducer/__main__.py
@@ -19,7 +19,7 @@ def new_events_notification_handler(msg):
     """Handle new events notifications."""
     notification = get_notification(msg)
 
-    if notification.header.get("catalogue") not in LISTEN_TO_CATALOGS:
+    if notification.header.get("catalogue") not in [*LISTEN_TO_CATALOGS, "rel"]:
         return
 
     workflow = {"workflow_name": EVENT_PRODUCE}

--- a/src/gobeventproducer/eventbuilder.py
+++ b/src/gobeventproducer/eventbuilder.py
@@ -1,4 +1,3 @@
-from gobcore.model.relations import get_relations_for_collection, split_relation_table_name
 from gobcore.typesystem import get_gob_type_from_info
 
 from gobeventproducer import gob_model
@@ -9,28 +8,11 @@ class EventDataBuilder:
 
     def __init__(self, gob_db_session, gob_db_base, catalogue: str, collection_name: str):
         self.db_session = gob_db_session
-        self.base = gob_db_base
+        base = gob_db_base
 
         self.collection = gob_model[catalogue]["collections"][collection_name]
-        self.tablename = gob_model.get_table_name(catalogue, collection_name)
-        self.basetable = getattr(self.base.classes, self.tablename)
-
-        self._init_relations(catalogue, collection_name)
-
-    def _init_relations(self, catalogue: str, collection_name: str):
-        self.relations = {}
-
-        for attr_name, relname in get_relations_for_collection(gob_model, catalogue, collection_name).items():
-            rel_table_name = gob_model.get_table_name("rel", relname)
-            self.relations[attr_name] = {
-                "relation_table_name": rel_table_name,
-                "dst_table_name": self._get_rel_dst_tablename(rel_table_name),
-            }
-
-    def _get_rel_dst_tablename(self, rel_table_name: str):
-        info = split_relation_table_name(rel_table_name)
-        reference = gob_model.get_reference_by_abbreviations(info["dst_cat_abbr"], info["dst_col_abbr"])
-        return gob_model.get_table_name_from_ref(reference)
+        tablename = gob_model.get_table_name(catalogue, collection_name)
+        self.basetable = getattr(base.classes, tablename)
 
     def build_event(self, tid: str) -> dict:
         """Build event data for object with given tid."""
@@ -39,26 +21,10 @@ class EventDataBuilder:
 
         result = {}
         for attr_name, attr in self.collection["attributes"].items():
-            if "Reference" in attr["type"]:
-                relation = self.relations[attr_name]
-                relation_table_rows = getattr(obj, f"{relation['relation_table_name']}_collection")
-                relation_obj = []
-                for row in relation_table_rows:
-                    dst_table = getattr(row, relation["dst_table_name"])
-                    rel = {
-                        "tid": dst_table._tid,
-                        "id": dst_table._id,
-                        "begin_geldigheid": str(row.begin_geldigheid) if row.begin_geldigheid else None,
-                        "eind_geldigheid": str(row.eind_geldigheid) if row.eind_geldigheid else None,
-                    }
-                    if hasattr(dst_table, "volgnummer"):
-                        rel["volgnummer"] = dst_table.volgnummer
-
-                    relation_obj.append(rel)
-
-                result[attr_name] = relation_obj
-            else:
+            if "Reference" not in attr["type"]:
+                # Skip relations
                 gob_type = get_gob_type_from_info(attr)
                 type_instance = gob_type.from_value(getattr(obj, attr_name))
-                result[attr_name] = str(type_instance.to_value)
+                result[attr_name] = type_instance.to_value
+        result["_gobid"] = getattr(obj, "_gobid")
         return result

--- a/src/gobeventproducer/mapping/nap/nap_peilmerken.yml
+++ b/src/gobeventproducer/mapping/nap/nap_peilmerken.yml
@@ -3,7 +3,7 @@ collection: peilmerken
 version: v1.0.1
 mapping:
   identificatie: identificatie
-  hoogteTovNap: hoogteTovNap
+  hoogte_tov_nap: hoogte_tov_nap
   jaar: jaar
   omschrijving: omschrijving
   windrichting: windrichting

--- a/src/gobeventproducer/naming.py
+++ b/src/gobeventproducer/naming.py
@@ -1,0 +1,7 @@
+from re import sub
+
+
+def camel_case(s):
+    """Transform snakeCase string to camel_case."""
+    s = sub(r"(_|-)+", " ", s).title().replace(" ", "")
+    return "".join([s[0].lower(), s[1:]])

--- a/src/tests/mapping/test_init.py
+++ b/src/tests/mapping/test_init.py
@@ -14,7 +14,7 @@ class TestMappingDefinitions(TestCase):
         self.assertEqual(
             {
                 "geometrie": "geometrie",
-                "hoogteTovNap": "hoogteTovNap",
+                "hoogte_tov_nap": "hoogte_tov_nap",
                 "identificatie": "identificatie",
                 "jaar": "jaar",
                 "ligt_in_bouwblok": "ligt_in_gebieden_bouwblok",

--- a/src/tests/test_eventbuilder.py
+++ b/src/tests/test_eventbuilder.py
@@ -7,33 +7,18 @@ from gobeventproducer.eventbuilder import EventDataBuilder
 class TestEventDataBuilder(TestCase):
     mock_gobmodel_data = {"cat": {"collections": {"coll": {"attributes": {}}}}}
 
-    @patch("gobeventproducer.eventbuilder.split_relation_table_name")
-    @patch("gobeventproducer.eventbuilder.get_relations_for_collection")
     @patch("gobeventproducer.eventbuilder.gob_model", spec_set=True)
-    def test_init(self, mock_model, mock_get_relations, mock_split_relation_table_name):
+    def test_init(self, mock_model):
         session = MagicMock()
         base = MagicMock()
         mock_model.__getitem__.return_value = self.mock_gobmodel_data["cat"]
         mock_model.get_table_name = lambda x, y: f"{x}_{y}"
-        mock_get_relations.return_value = {
-            "rel_a_attr": "a",
-            "rel_b_attr": "b",
-        }
-        mock_split_relation_table_name.side_effect = lambda x: {"dst_cat_abbr": "dstcat", "dst_col_abbr": x}
         mock_model.get_reference_by_abbreviations = lambda x, y: y
         mock_model.get_table_name_from_ref = lambda y: f"dst_table_{y}"
         edb = EventDataBuilder(session, base, "cat", "coll")
 
         self.assertEqual(session, edb.db_session)
-        self.assertEqual(base, edb.base)
         self.assertEqual(self.mock_gobmodel_data["cat"]["collections"]["coll"], edb.collection)
-        self.assertEqual("cat_coll", edb.tablename)
-
-        expected_relations = {
-            "rel_a_attr": {"dst_table_name": "dst_table_rel_a", "relation_table_name": "rel_a"},
-            "rel_b_attr": {"dst_table_name": "dst_table_rel_b", "relation_table_name": "rel_b"},
-        }
-        self.assertEqual(expected_relations, edb.relations)
 
     def test_build_event(self):
         class RelationObject:
@@ -55,6 +40,7 @@ class TestEventDataBuilder(TestCase):
             manyref_to_c = None
             ref_to_d = None
             manyref_to_d = None
+            _gobid = 45
             rel_tst_rta_tst_rtc_ref_to_c_collection = [
                 RelationObject("id1", "begingeldigheid", None, "test_catalogue_rel_test_entity_c", True),
                 RelationObject("id2", "begingeldigheid", "eindgeldigheid", "test_catalogue_rel_test_entity_c", True),
@@ -77,48 +63,9 @@ class TestEventDataBuilder(TestCase):
         edb.db_session.query.return_value.filter.return_value.one.return_value = DbObject()
 
         expected = {
-            "id": "42",
+            "id": 42,
+            "_gobid": 45,
             "identificatie": "identificatie",
-            "manyref_to_c": [
-                {
-                    "begin_geldigheid": "begingeldigheid",
-                    "eind_geldigheid": None,
-                    "id": "id3",
-                    "tid": "id3",
-                    "volgnummer": 1,
-                },
-                {
-                    "begin_geldigheid": "begingeldigheid",
-                    "eind_geldigheid": "eindgeldigheid",
-                    "id": "id4",
-                    "tid": "id4",
-                    "volgnummer": 1,
-                },
-            ],
-            "manyref_to_d": [
-                {"begin_geldigheid": "begingeldigheid", "eind_geldigheid": None, "id": "id7", "tid": "id7"},
-                {"begin_geldigheid": "begingeldigheid", "eind_geldigheid": "eindgeldigheid", "id": "id8", "tid": "id8"},
-            ],
-            "ref_to_c": [
-                {
-                    "begin_geldigheid": "begingeldigheid",
-                    "eind_geldigheid": None,
-                    "id": "id1",
-                    "tid": "id1",
-                    "volgnummer": 1,
-                },
-                {
-                    "begin_geldigheid": "begingeldigheid",
-                    "eind_geldigheid": "eindgeldigheid",
-                    "id": "id2",
-                    "tid": "id2",
-                    "volgnummer": 1,
-                },
-            ],
-            "ref_to_d": [
-                {"begin_geldigheid": "begingeldigheid", "eind_geldigheid": None, "id": "id5", "tid": "id5"},
-                {"begin_geldigheid": "begingeldigheid", "eind_geldigheid": "eindgeldigheid", "id": "id6", "tid": "id6"},
-            ],
         }
 
         self.assertEqual(expected, edb.build_event("the tid"))

--- a/src/tests/test_mapper.py
+++ b/src/tests/test_mapper.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest import TestCase
 
-from gobeventproducer.mapper import EventDataMapper, PassThroughEventDataMapper
+from gobeventproducer.mapper import EventDataMapper, PassThroughEventDataMapper, RelationEventDataMapper
 from gobeventproducer.mapping import MappingDefinitionLoader
 
 eventdata = {
@@ -24,11 +24,19 @@ class TestPassThroughEventDataMapper(TestCase):
         mapper = PassThroughEventDataMapper()
         self.assertEqual(eventdata, mapper.map(eventdata))
 
+    def test_get_mapped_name_reverse(self):
+        mapper = PassThroughEventDataMapper()
+        self.assertEqual("some_str", mapper.get_mapped_name_reverse("some_str"))
+
 
 class TestEventDataMapper(TestCase):
-    def test_map(self):
+
+    def setUp(self) -> None:
         mock_definition_path = Path(__file__).parent / "mocks" / "mock_mapping_definition.yml"
         mapping_definition = MappingDefinitionLoader()._load_mapping_definition(mock_definition_path)
+        self.mapper = EventDataMapper(mapping_definition)
+
+    def test_map(self):
         expected = {
             "ligt_in_bouwblok": {
                 "tid": "thet id",
@@ -44,5 +52,38 @@ class TestEventDataMapper(TestCase):
             },
         }
 
-        mapper = EventDataMapper(mapping_definition)
+        self.assertEqual(expected, self.mapper.map(eventdata))
+
+    def test_get_mapped_name_reverse(self):
+        self.assertEqual("ligt_in_bouwblok", self.mapper.get_mapped_name_reverse("ligt_in_gebieden_bouwblok"))
+
+        with self.assertRaisesRegex(Exception, "non_existent cannot be found"):
+            self.mapper.get_mapped_name_reverse("non_existent")
+
+
+class TestRelationEventDataMapper(TestCase):
+
+    def test_map_without_states(self):
+        mapper = RelationEventDataMapper()
+
+        eventdata = {
+            "_gobid": 45,
+            "src_id": "248",
+            "dst_id": "202",
+            "begin_geldigheid": "2023-01-01 00:00:00",
+            "eind_geldigheid": None,
+            "dst_volgnummer": None,
+            "other_field": "some value"
+        }
+
+        expected = {
+            "id": 45,
+            "src_id": "248",
+            "dst_id": "202",
+            "begin_geldigheid": "2023-01-01 00:00:00",
+            "eind_geldigheid": None,
+            "src_volgnummer": None,
+            "dst_volgnummer": None,
+        }
+
         self.assertEqual(expected, mapper.map(eventdata))

--- a/src/tests/test_naming.py
+++ b/src/tests/test_naming.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+
+from gobeventproducer.naming import camel_case
+
+
+class TestNaming(TestCase):
+
+    def test_camel_case(self):
+        cases = [
+            ("test_case", "testCase"),
+            ("test_case_2", "testCase2"),
+            ("test", "test"),
+        ]
+
+        for _in, _out in cases:
+            self.assertEqual(_out, camel_case(_in))


### PR DESCRIPTION
Relation table events are sent on with catalog "nap" and collection "peilmerken_ligtInBouwblok" for example. This is the convention in the schematools repo, so that's the easiest way to use it.