### PR TITLE
76210: Implement support for generating an initial load of ADD events

### DIFF
--- a/src/gobeventproducer/eventbuilder.py
+++ b/src/gobeventproducer/eventbuilder.py
@@ -6,19 +6,11 @@ from gobeventproducer import gob_model
 class EventDataBuilder:
     """Helper class that generates external event data."""
 
-    def __init__(self, gob_db_session, gob_db_base, catalogue: str, collection_name: str):
-        self.db_session = gob_db_session
-        base = gob_db_base
+    def __init__(self, catalogue_name: str, collection_name: str):
+        self.collection = gob_model[catalogue_name]["collections"][collection_name]
 
-        self.collection = gob_model[catalogue]["collections"][collection_name]
-        tablename = gob_model.get_table_name(catalogue, collection_name)
-        self.basetable = getattr(base.classes, tablename)
-
-    def build_event(self, tid: str) -> dict:
-        """Build event data for object with given tid."""
-        query = self.db_session.query(self.basetable).filter(self.basetable._tid == tid)
-        obj = query.one()
-
+    def build_event(self, obj: object) -> dict:
+        """Build event data for SQLAlchemy object."""
         result = {}
         for attr_name, attr in self.collection["attributes"].items():
             if "Reference" not in attr["type"]:

--- a/src/gobeventproducer/producer.py
+++ b/src/gobeventproducer/producer.py
@@ -1,8 +1,11 @@
 import logging
+from typing import Union
 
+from gobcore.events.import_events import ADD
 from gobcore.message_broker.async_message_broker import AsyncConnection
 from gobcore.message_broker.config import CONNECTION_PARAMS, EVENTS_EXCHANGE
 from gobcore.model.relations import split_relation_table_name
+from more_itertools import peekable
 
 from gobeventproducer import gob_model
 from gobeventproducer.database.gob.contextmanager import GobDatabaseConnection
@@ -70,18 +73,20 @@ class EventProducer:
             }
             self.routing_key = f"{catalog}.{collection_name}"
 
-    def _add_event(self, event, connection, event_builder: EventDataBuilder):
+    def _publish(self, event: dict, connection):
+        connection.publish(EVENTS_EXCHANGE, self.routing_key, event)
+
+    def _build_event(self, event_action: str, event_id: Union[str, None], object_tid: str, data: object, event_builder):
         header = {
             **self.header_data,
-            "event_type": event.action,
-            "event_id": event.eventid,
-            "tid": event.tid,
+            "event_type": event_action,
+            "event_id": event_id,
+            "tid": object_tid,
         }
-        data = event_builder.build_event(event.tid)
+        data = event_builder.build_event(data)
         transformed_data = self.mapper.map(data)
 
-        msg = {"header": header, "data": transformed_data}
-        connection.publish(EVENTS_EXCHANGE, self.routing_key, msg)
+        return {"header": header, "data": transformed_data}
 
     def produce(self, min_eventid: int, max_eventid: int):
         """Produce external events starting from min_eventid (exclusive) until max_eventid (inclusive)."""
@@ -92,7 +97,7 @@ class EventProducer:
         ) as gobdb:
             last_eventid = localdb.get_last_eventid()
 
-            event_builder = EventDataBuilder(gobdb.session, gobdb.base, self.catalog, self.collection)
+            event_builder = EventDataBuilder(self.catalog, self.collection)
 
             # Ideally we would remove the need for the database. We keep the database in place now to be able to spot
             # any errors thay may arise when min_eventid does not match the expected last_eventid.
@@ -113,10 +118,46 @@ class EventProducer:
 
             with AsyncConnection(CONNECTION_PARAMS) as rabbitconn:
                 for event in events:
-                    self._add_event(event, rabbitconn, event_builder)
+                    obj = gobdb.get_object(event.tid)
+                    external_event = self._build_event(event.action, event.eventid, event.tid, obj, event_builder)
+                    self._publish(external_event, rabbitconn)
 
                     gobdb.session.expunge(event)
                     localdb.set_last_eventid(event.eventid)
                     self.total_cnt += 1
 
-            self.logger.info(f"Produced {self.total_cnt} events")
+            self.logger.info(f"Produced {self.total_cnt} events.")
+
+    def produce_initial(self):
+        """Produce external ADD events for the current state of the database.
+
+        Adds the 'full_load' property to the header and 'finished': True to the last event of the sequence so that the
+        consumer knows when the full_load is finished (and a table can be replaced, for example).
+        """
+        with LocalDatabaseConnection(self.catalog, self.collection) as localdb, GobDatabaseConnection(
+            self.catalog, self.collection, self.logger
+        ) as gobdb:
+            event_builder = EventDataBuilder(self.catalog, self.collection)
+            objects = peekable(gobdb.get_objects())
+            first_of_sequence = True
+
+            self.logger.info("Start generating ADD events for current database state")
+
+            with AsyncConnection(CONNECTION_PARAMS) as rabbitconn:
+                last_eventid = None
+                for obj in objects:
+                    external_event = self._build_event(ADD.name, None, obj._tid, obj, event_builder)
+
+                    external_event["header"] |= {
+                        "full_load_sequence": True,
+                        "first_of_sequence": first_of_sequence,
+                        "last_of_sequence": False if objects.peek(None) else True,
+                    }
+
+                    self._publish(external_event, rabbitconn)
+                    self.total_cnt += 1
+                    last_eventid = obj._last_event if last_eventid is None else max(last_eventid, obj._last_event)
+                    first_of_sequence = False
+                localdb.set_last_eventid(last_eventid)
+
+            self.logger.info(f"Produced {self.total_cnt} events.")

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,6 @@
 alembic==1.9.3
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.8.11#egg=gobconfig
 -e git+https://github.com/Amsterdam/GOB-Core.git@v2.5.0#egg=gobcore
+more-itertools==9.1.0
 pydantic==1.10.6
 types-PyYAML==6.0.12.8

--- a/src/tests/mocks/eventbuilder.py
+++ b/src/tests/mocks/eventbuilder.py
@@ -1,6 +1,0 @@
-class MockEventBuilder:
-    def __init__(self, *args):
-        pass
-
-    def build_event(self, tid):
-        return {"tid": tid, "a": "A", "b": "B"}

--- a/src/tests/test_eventbuilder.py
+++ b/src/tests/test_eventbuilder.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from gobeventproducer.eventbuilder import EventDataBuilder
 
@@ -9,30 +9,11 @@ class TestEventDataBuilder(TestCase):
 
     @patch("gobeventproducer.eventbuilder.gob_model", spec_set=True)
     def test_init(self, mock_model):
-        session = MagicMock()
-        base = MagicMock()
         mock_model.__getitem__.return_value = self.mock_gobmodel_data["cat"]
-        mock_model.get_table_name = lambda x, y: f"{x}_{y}"
-        mock_model.get_reference_by_abbreviations = lambda x, y: y
-        mock_model.get_table_name_from_ref = lambda y: f"dst_table_{y}"
-        edb = EventDataBuilder(session, base, "cat", "coll")
-
-        self.assertEqual(session, edb.db_session)
+        edb = EventDataBuilder("cat", "coll")
         self.assertEqual(self.mock_gobmodel_data["cat"]["collections"]["coll"], edb.collection)
 
     def test_build_event(self):
-        class RelationObject:
-            # Create mock relation for DbObject
-            def __init__(self, id, begin_geldigheid, eind_geldigheid, dst_name, dst_has_states):
-                self.begin_geldigheid = begin_geldigheid
-                self.eind_geldigheid = eind_geldigheid
-
-                dst_fields = {"_id": id, "_tid": id}
-                if dst_has_states:
-                    dst_fields["volgnummer"] = 1
-
-                self.__setattr__(dst_name, type("DstTable", (), dst_fields))
-
         class DbObject:
             id = 42
             identificatie = "identificatie"
@@ -41,26 +22,8 @@ class TestEventDataBuilder(TestCase):
             ref_to_d = None
             manyref_to_d = None
             _gobid = 45
-            rel_tst_rta_tst_rtc_ref_to_c_collection = [
-                RelationObject("id1", "begingeldigheid", None, "test_catalogue_rel_test_entity_c", True),
-                RelationObject("id2", "begingeldigheid", "eindgeldigheid", "test_catalogue_rel_test_entity_c", True),
-            ]
-            rel_tst_rta_tst_rtc_manyref_to_c_collection = [
-                RelationObject("id3", "begingeldigheid", None, "test_catalogue_rel_test_entity_c", True),
-                RelationObject("id4", "begingeldigheid", "eindgeldigheid", "test_catalogue_rel_test_entity_c", True),
-            ]
-            rel_tst_rta_tst_rtd_ref_to_d_collection = [
-                RelationObject("id5", "begingeldigheid", None, "test_catalogue_rel_test_entity_d", False),
-                RelationObject("id6", "begingeldigheid", "eindgeldigheid", "test_catalogue_rel_test_entity_d", False),
-            ]
-            rel_tst_rta_tst_rtd_manyref_to_d_collection = [
-                RelationObject("id7", "begingeldigheid", None, "test_catalogue_rel_test_entity_d", False),
-                RelationObject("id8", "begingeldigheid", "eindgeldigheid", "test_catalogue_rel_test_entity_d", False),
-            ]
 
-        edb = EventDataBuilder(MagicMock(), MagicMock(), "test_catalogue", "rel_test_entity_a")
-
-        edb.db_session.query.return_value.filter.return_value.one.return_value = DbObject()
+        edb = EventDataBuilder("test_catalogue", "rel_test_entity_a")
 
         expected = {
             "id": 42,
@@ -68,4 +31,4 @@ class TestEventDataBuilder(TestCase):
             "identificatie": "identificatie",
         }
 
-        self.assertEqual(expected, edb.build_event("the tid"))
+        self.assertEqual(expected, edb.build_event(DbObject()))

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -73,6 +73,39 @@ class TestMain(TestCase):
         with self.assertRaises(AssertionError):
             event_produce_handler({})
 
+    @patch("gobeventproducer.__main__.logger")
+    @patch("gobeventproducer.__main__.EventProducer")
+    def test_event_produce_handler_full_load(self, mock_producer, mock_logger):
+        msg = {
+            "header": {
+                "catalogue": "CAT",
+                "collection": "COLL",
+                "mode": "full_load",
+            },
+        }
+        mock_producer.return_value.total_cnt = 14804
+
+        result = event_produce_handler(msg)
+        self.assertEqual(
+            {
+                "header": msg["header"],
+                "summary": {
+                    "produced": 14804,
+                },
+            },
+            result,
+        )
+
+        mock_producer.assert_has_calls(
+            [
+                call("CAT", "COLL", mock_logger),
+                call().produce_initial()
+            ]
+        )
+
+        with self.assertRaises(AssertionError):
+            event_produce_handler({})
+
     @patch("gobeventproducer.__main__.connect")
     @patch("gobeventproducer.__main__.MessagedrivenService")
     def test_main_entry(self, mock_messagedriven_service, mock_connect):

--- a/src/tests/test_producer.py
+++ b/src/tests/test_producer.py
@@ -1,18 +1,37 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, call, patch
 
+from gobeventproducer.eventbuilder import EventDataBuilder
 from gobeventproducer.mapper import PassThroughEventDataMapper, RelationEventDataMapper
 from gobeventproducer.producer import EventProducer
-from tests.mocks.asyncconnection import AsyncConnectionMock
-from tests.mocks.eventbuilder import MockEventBuilder
 
 
 class MockEvent:
-    def __init__(self, id):
+    def __init__(self, id, action, tid):
         self.eventid = id
+        self.action = action
+        self.tid = tid
 
     def __eq__(self, other):
         return self.eventid == other.eventid
+
+
+mock_model = {
+    'cat': {
+        'collections': {
+            'coll': {
+                'attributes': {
+                    'some': {
+                        'type': 'GOB.String',
+                    },
+                    'int': {
+                        'type': 'GOB.Integer',
+                    }
+                }
+            }
+        }
+    }
+}
 
 
 class TestEventProducer(TestCase):
@@ -39,90 +58,113 @@ class TestEventProducer(TestCase):
         }, p.header_data)
         self.assertEqual("nap.rel.peilmerken_ligtInBouwblok", p.routing_key)
 
-    def test_add_event(self):
-        event = MagicMock()
-        event.action = "ACTION"
-        event.eventid = "ID"
-        event.data = {
+    @patch("gobeventproducer.producer.gob_model", mock_model)
+    @patch("gobeventproducer.eventbuilder.gob_model", mock_model)
+    def test_build_event(self):
+        """Mainly to test that mapper is called correctly, as the rest of this method is also tested in test_produce."""
+        data = type('DbObject', (), {
             "some": "data",
             "int": 8042,
-        }
-        event.last_event = 15480
-        event.catalogue = "CAT"
-        event.entity = "COLL"
-        event.tid = "TID"
+            "_gobid": 24,
+        })
 
         p = EventProducer("cat", "coll", MagicMock())
         p.mapper = MagicMock()
         p.mapper.map.side_effect = lambda x: {**x, "transformed": True}
 
-        connection = MagicMock()
-        p._add_event(event, connection, MockEventBuilder())
-        connection.publish.assert_called_with(
-            "gob.events",
-            "cat.coll",
-            {
-                "header": {
-                    "event_type": "ACTION",
-                    "event_id": "ID",
-                    "tid": "TID",
-                    "catalog": "cat",
-                    "collection": "coll",
-                },
-                "data": {
-                    "tid": "TID",
-                    "a": "A",
-                    "b": "B",
-                    "transformed": True,
-                },
-            },
+        result = p._build_event(
+            "ACTION",
+            "ID",
+            "TID",
+            data,
+            EventDataBuilder('cat', 'coll')
         )
+        self.assertEqual(result, {
+            "header": {
+                "event_type": "ACTION",
+                "event_id": "ID",
+                "tid": "TID",
+                "catalog": "cat",
+                "collection": "coll",
+            },
+            "data": {
+                "transformed": True,
+                "_gobid": 24,
+                "int": 8042,
+                "some": "data",
+            },
+        })
         p.mapper.map.assert_called_with(
             {
-                "tid": "TID",
-                "a": "A",
-                "b": "B",
+                "_gobid": 24,
+                "int": 8042,
+                "some": "data",
             }
         )
 
+    @patch("gobeventproducer.producer.gob_model", mock_model)
+    @patch("gobeventproducer.eventbuilder.gob_model", mock_model)
     @patch("gobeventproducer.producer.LocalDatabaseConnection")
     @patch("gobeventproducer.producer.GobDatabaseConnection")
-    @patch("gobeventproducer.producer.AsyncConnection", AsyncConnectionMock)
-    @patch("gobeventproducer.producer.EventDataBuilder", MockEventBuilder)
-    def test_produce(self, mock_gobdb, mock_localdb):
-        event_cnt = 5
-
+    @patch("gobeventproducer.producer.AsyncConnection")
+    def test_produce(self, mock_rabbit, mock_gobdb, mock_localdb):
+        rabbit_instance = mock_rabbit.return_value.__enter__.return_value
         localdb_instance = mock_localdb.return_value.__enter__.return_value
         gobdb_instance = mock_gobdb.return_value.__enter__.return_value
-        gobdb_instance.get_events = MagicMock(return_value=[MockEvent(i) for i in range(event_cnt)])
 
-        p = EventProducer("", "", MagicMock())
-        p._add_event = MagicMock()
+        mock_events = [
+            MockEvent(24, "ADD", 200),
+            MockEvent(25, "MODIFY", 201)
+        ]
+        gobdb_instance.get_events = MagicMock(return_value=mock_events)
+        gobdb_instance.get_object = MagicMock(side_effect=lambda tid: type('DbObject', (), {
+            "some": "data",
+            "int": 8042,
+            "_gobid": tid,  # Of course not the same thing, but for the purpose of testing.
+        }))
+
+        p = EventProducer("cat", "coll", MagicMock())
         p.gob_db_session = MagicMock()
         localdb_instance.get_last_eventid = MagicMock(return_value=100)
 
         p.produce(100, 200)
 
         gobdb_instance.get_events.assert_called_with(100, 200)
-        self.assertEqual(event_cnt, p._add_event.call_count)
-        gobdb_instance.session.expunge.assert_has_calls(
-            [
-                call(MockEvent(0)),
-                call(MockEvent(1)),
-                call(MockEvent(2)),
-                call(MockEvent(3)),
-                call(MockEvent(4)),
-            ]
-        )
-        localdb_instance.set_last_eventid.assert_has_calls(
-            [
-                call(0),
-                call(1),
-                call(2),
-                call(3),
-                call(4),
-            ]
-        )
+
+        rabbit_instance.publish.assert_has_calls([
+            call("gob.events", "cat.coll", {
+                "header": {
+                    "catalog": "cat",
+                    "collection": "coll",
+                    "event_type": "ADD",
+                    "event_id": 24,
+                    "tid": 200,
+                },
+                "data": {
+                    "_gobid": 200,
+                    "int": 8042,
+                    "some": "data",
+                }
+            }),
+            call("gob.events", "cat.coll", {
+                "header": {
+                    "catalog": "cat",
+                    "collection": "coll",
+                    "event_type": "MODIFY",
+                    "event_id": 25,
+                    "tid": 201,
+                },
+                "data": {
+                    "_gobid": 201,
+                    "int": 8042,
+                    "some": "data",
+                }
+            }),
+        ])
+
+        gobdb_instance.get_object.assert_has_calls([call(event.tid) for event in mock_events])
+        gobdb_instance.session.expunge.assert_has_calls([call(event) for event in mock_events])
+        localdb_instance.set_last_eventid.assert_has_calls([call(24), call(25)])
         p.logger.warning.assert_not_called()
 
         # min_eventid does not match start_event
@@ -136,3 +178,86 @@ class TestEventProducer(TestCase):
 
         p.produce(110, 200)
         p.logger.warning.assert_called_with("Have no previous produced events in database. Starting at beginning")
+
+    @patch("gobeventproducer.producer.gob_model", mock_model)
+    @patch("gobeventproducer.eventbuilder.gob_model", mock_model)
+    @patch("gobeventproducer.producer.LocalDatabaseConnection")
+    @patch("gobeventproducer.producer.GobDatabaseConnection")
+    @patch("gobeventproducer.producer.AsyncConnection")
+    def test_produce_initial(self, mock_rabbit, mock_gobdb, mock_localdb):
+        gobdb_instance = mock_gobdb.return_value.__enter__.return_value
+        localdb_instance = mock_localdb.return_value.__enter__.return_value
+        rabbit_instance = mock_rabbit.return_value.__enter__.return_value
+
+        create_object = lambda tid: type('DbObject', (), {
+            "some": "data",
+            "int": 8042,
+            "_last_event": int(tid),
+            "_gobid": int(tid),  # Of course not the same thing, but for the purpose of testing.
+            "_tid": tid,
+        })
+
+        gobdb_instance.get_objects.return_value = iter([
+            create_object("19"),
+            create_object("22"),
+            create_object("24"),
+        ])
+
+        p = EventProducer("cat", "coll", MagicMock())
+        p.produce_initial()
+
+        rabbit_instance.publish.assert_has_calls([
+            call("gob.events", "cat.coll", {
+                "header": {
+                    "catalog": "cat",
+                    "collection": "coll",
+                    "event_type": "ADD",
+                    "event_id": None,
+                    "tid": "19",
+                    "full_load_sequence": True,
+                    "first_of_sequence": True,
+                    "last_of_sequence": False,
+                },
+                "data": {
+                    "_gobid": 19,
+                    "int": 8042,
+                    "some": "data",
+                }
+            }),
+            call("gob.events", "cat.coll", {
+                "header": {
+                    "catalog": "cat",
+                    "collection": "coll",
+                    "event_type": "ADD",
+                    "event_id": None,
+                    "tid": "22",
+                    "full_load_sequence": True,
+                    "first_of_sequence": False,
+                    "last_of_sequence": False,
+                },
+                "data": {
+                    "_gobid": 22,
+                    "int": 8042,
+                    "some": "data",
+                }
+            }),
+            call("gob.events", "cat.coll", {
+                "header": {
+                    "catalog": "cat",
+                    "collection": "coll",
+                    "event_type": "ADD",
+                    "event_id": None,
+                    "tid": "24",
+                    "full_load_sequence": True,
+                    "first_of_sequence": False,
+                    "last_of_sequence": True,
+                },
+                "data": {
+                    "_gobid": 24,
+                    "int": 8042,
+                    "some": "data",
+                }
+            }),
+        ])
+
+        localdb_instance.set_last_eventid.assert_called_once_with(24)


### PR DESCRIPTION
For a full load, we generate ADD events for all objects in a table.
- Every event gets three extra header fields: `full_load_sequence` is set to True for the complete sequence. `last_of_sequence` and `first_of_sequence` are False for all events, except for the last and first events, so that the consumer knows when to take action.
- The full load uses the same job handler as the regular handler, so that workflow makes sure no two jobs run at the same time.