### PR TITLE
Ignore missing relations in GOB when constructing events. Fixes BRK2 …

### DIFF
--- a/src/gobeventproducer/utils/relations.py
+++ b/src/gobeventproducer/utils/relations.py
@@ -22,6 +22,9 @@ class RelationInfoBuilder:
         result = {}
 
         for attr_name, relname in get_relations_for_collection(gob_model, catalogue_name, collection_name).items():
+            if relname is None:
+                # Relation is not (yet) defined in GOB
+                continue
             rel_table_name = gob_model.get_table_name("rel", relname)
             result[attr_name] = RelationInfo(
                 relation_table_name=rel_table_name, dst_table_name=cls._get_rel_dst_tablename(rel_table_name)

--- a/src/tests/utils/test_relations.py
+++ b/src/tests/utils/test_relations.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from gobeventproducer.utils.relations import RelationInfo, RelationInfoBuilder, gob_model
+
+
+class TestRelationInfoBuilder(TestCase):
+
+    @patch("gobeventproducer.utils.relations.get_relations_for_collection")
+    def test_build(self, mock_get_relations):
+        mock_get_relations.return_value = {
+            "is_bron_voor_brk_tenaamstelling": "brk2_sdl_brk2_tng_is_bron_voor_brk_tenaamstelling",
+            "is_bron_voor_brk_aantekening_kadastraal_object": "brk2_sdl_brk2_akt__is_bron_voor_brk_akt_",
+            "is_bron_voor_brk_aantekening_recht": "brk2_sdl_brk2_art__is_bron_voor_brk_art_",
+            "is_bron_voor_brk_erfpachtcanon": None,
+        }
+
+        res = RelationInfoBuilder().build("brk2", "stukdelen")
+
+        self.assertEqual(res, {
+            "is_bron_voor_brk_aantekening_kadastraal_object": RelationInfo("rel_brk2_sdl_brk2_akt__is_bron_voor_brk_akt_", "brk2_aantekeningenkadastraleobjecten"),
+            "is_bron_voor_brk_aantekening_recht": RelationInfo("rel_brk2_sdl_brk2_art__is_bron_voor_brk_art_", "brk2_aantekeningenrechten"),
+            "is_bron_voor_brk_tenaamstelling": RelationInfo("rel_brk2_sdl_brk2_tng_is_bron_voor_brk_tenaamstelling", "brk2_tenaamstellingen"),
+        })
+
+        mock_get_relations.assert_called_with(gob_model, "brk2", "stukdelen")


### PR DESCRIPTION
…stukdelen erfpacht error