### PR TITLE
Set application to None when starting new workflow after notification…

### DIFF
--- a/src/gobeventproducer/__main__.py
+++ b/src/gobeventproducer/__main__.py
@@ -42,7 +42,7 @@ def new_events_notification_handler(msg):
     arguments = {
         "catalogue": notification.header.get("catalogue"),
         "collection": notification.header.get("collection"),
-        "application": notification.header.get("application"),
+        "application": None,  # To avoid that multiple produce jobs run in parallel for different applications
         "process_id": notification.header.get("process_id"),
         "contents": notification.contents,
     }

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -27,7 +27,7 @@ class TestMain(TestCase):
             {
                 "catalogue": "nap",
                 "collection": "peilmerken",
-                "application": "APPL",
+                "application": None,
                 "process_id": "PID",
                 "contents": mock_get_notification.return_value.contents,
             },


### PR DESCRIPTION
… to avoid parallel running produce jobs